### PR TITLE
Fix double slash in logout URL causing 404

### DIFF
--- a/conf/main-web.py.patch
+++ b/conf/main-web.py.patch
@@ -7,7 +7,7 @@
 -        return redirect(url_for('web.login'))
 +#       return redirect(url_for('web.login'))
 +        if config.config_login_type == constants.LOGIN_LDAP:
-+            return redirect(request.host_url + '/yunohost/sso/?action=logout')
++            return redirect(request.host_url + 'yunohost/sso/?action=logout')
 +        else:
 +            return redirect(url_for('web.login'))
 

--- a/conf/main-web.py.revert.patch
+++ b/conf/main-web.py.revert.patch
@@ -6,7 +6,7 @@
      else:
 -#       return redirect(url_for('web.login'))
 -        if config.config_login_type == constants.LOGIN_LDAP:
--            return redirect(request.host_url + '/yunohost/sso/?action=logout')
+-            return redirect(request.host_url + 'yunohost/sso/?action=logout')
 -        else:
 -            return redirect(url_for('web.login'))
 +        return redirect(url_for('web.login'))


### PR DESCRIPTION
## Problem

The logout URL contained a double slash (//yunohost/sso/?action=logout), which caused a 404 error when users tried to log out.
Fix by removing the extra slash in patch.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)