### PR TITLE
Mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Browsing, reading and downloading eBooks using a Calibre database
 
-[![Version: 0.96.25~ynh3](https://img.shields.io/badge/Version-0.96.25~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/calibreweb/)
+[![Version: 0.96.25~ynh4](https://img.shields.io/badge/Version-0.96.25~ynh4-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/calibreweb/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/calibreweb"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/generate_password_hash.py
+++ b/conf/generate_password_hash.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Permet de générer le hash pour le password
+import sys
+path=sys.argv[2]
+sys.path.append(path)
+from werkzeug.security import generate_password_hash
+password=sys.argv[1]
+print generate_password_hash(password)

--- a/conf/generate_password_hash.py
+++ b/conf/generate_password_hash.py
@@ -6,4 +6,4 @@ path=sys.argv[2]
 sys.path.append(path)
 from werkzeug.security import generate_password_hash
 password=sys.argv[1]
-print generate_password_hash(password)
+print(generate_password_hash(password))

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Calibre-web"
 description.en = "Browsing, reading and downloading eBooks using a Calibre database"
 description.fr = "Explorer, lire et télécharger des eBooks à partir d'une base de données Calibre"
 
-version = "0.96.25~ynh3"
+version = "0.96.25~ynh4"
 
 maintainers = ["Krakinou"]
 
@@ -98,6 +98,7 @@ ram.runtime = "200M"
     autoupdate.asset.arm64 = "kepubify-linux-arm64"
 
     [resources.system_user]
+    allow_email = true
 
     [resources.install_dir]
 

--- a/scripts/install
+++ b/scripts/install
@@ -82,7 +82,7 @@ sqlite3 $install_dir/app.db "UPDATE settings SET mail_server='$domain'"
 sqlite3 $install_dir/app.db "UPDATE settings SET mail_port='587'"
 sqlite3 $install_dir/app.db "UPDATE settings SET mail_use_ssl='1'"
 sqlite3 $install_dir/app.db "UPDATE settings SET mail_login='$app'"
-sqlite3 $install_dir/app.db "UPDATE settings SET mail_password='$mail_pwd'"
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_password_e='$(python ../conf/generate_password_hash.py "$mail_pwd" $install_dir/vendor)' WHERE ID=1"
 sqlite3 $install_dir/app.db "UPDATE settings SET mail_from='$app@$domain'"
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -73,6 +73,19 @@ fi
 ynh_app_setting_set --key="calibre_dir" --value="$calibre_dir"
 
 #=================================================
+# MAIL CONFIGURATION
+#=================================================
+
+ynh_script_progression "Adjusting mail configuration..."
+
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_server='$domain'"
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_port='587'"
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_use_ssl='1'"
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_login='$app'"
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_password='$mail_pwd'"
+sqlite3 $install_dir/app.db "UPDATE settings SET mail_from='$app@$domain'"
+
+#=================================================
 # NGINX CONFIGURATION
 #=================================================
 ynh_script_progression "Setting up system configuration..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -85,7 +85,7 @@ if ynh_app_upgrading_from_version_before 0.96.25~ynh4; then
 	sqlite3 $install_dir/app.db "UPDATE settings SET mail_port='587'"
 	sqlite3 $install_dir/app.db "UPDATE settings SET mail_use_ssl='1'"
 	sqlite3 $install_dir/app.db "UPDATE settings SET mail_login='$app'"
-	sqlite3 $install_dir/app.db "UPDATE settings SET mail_password='$mail_pwd'"
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_password_e='$(python ../conf/generate_password_hash.py "$mail_pwd" $install_dir/vendor)' WHERE ID=1"
 	sqlite3 $install_dir/app.db "UPDATE settings SET mail_from='$app@$domain'"
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -78,6 +78,17 @@ if sqlite3 $install_dir/app.db "SELECT config_kepubifypath FROM settings" | grep
 	eval sqlite3 $install_dir/app.db "\"UPDATE settings SET config_kepubifypath='/opt/kepubify/$app/kepubify' WHERE ID=1\""
 fi
 
+if ynh_app_upgrading_from_version_before 0.96.25~ynh4; then
+   	ynh_script_progression "Adjusting mail configuration..."
+
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_server='$domain'"
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_port='587'"
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_use_ssl='1'"
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_login='$app'"
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_password='$mail_pwd'"
+	sqlite3 $install_dir/app.db "UPDATE settings SET mail_from='$app@$domain'"
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================


### PR DESCRIPTION
## Problem

Creating this pr for the record.

I’ve managed to make mails work nearly out of the box (https://github.com/YunoHost-Apps/calibreweb_ynh/issues/75).

The issue is that line `sqlite3 $install_dir/app.db "UPDATE settings SET mail_password='$mail_pwd'"` is not correct. It is rather the column `mail_password_e` that is used, but it is… encrypted. If I manually check the `mail_pwd` in `/etc/yunohost/apps/calibreweb/settings.yml` and set it through Calibreweb interface, mail works. But I think it’s to much hassle to try to encrypt ourselves with the same encryption tool as CW for this to work out of the box 😅

## Solution

Leave things like now 
Or don’t fill the `mail_password_e` column (mail_password can in any case be ditched), but mention in the ADMIN.md that the mail password is `__MAIL_PWD__` (but I don’t know how secure it is to do so?)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
