### PR TITLE
Set SSOWAT basic auth header stripping to false

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -150,6 +150,7 @@ ynh_config_add_fail2ban --logpath="$log_file" --failregex="^.*LDAP Login failed 
 #=================================================
 ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
 
+yunohost app ssowatconf
 #=================================================
 # RELOAD NGINX
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -146,6 +146,11 @@ fi
 ynh_config_add_fail2ban --logpath="$log_file" --failregex="^.*LDAP Login failed for user .* IP-address: <HOST>.*$"
 
 #=================================================
+# SET SSOWAT BASIC AUTH HEADER HANDLING FOR OPDS
+#=================================================
+ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
+
+#=================================================
 # RELOAD NGINX
 #=================================================
 ynh_script_progression "Start $app..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -210,6 +210,8 @@ ynh_config_add_fail2ban --logpath="$log_file" --failregex="^.*LDAP Login failed 
 #=================================================
 ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
 
+yunohost app ssowatconf
+
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -204,6 +204,12 @@ fi
 # Create a dedicated Fail2Ban config
 ynh_config_add_fail2ban --logpath="$log_file" --failregex="^.*LDAP Login failed for user .* IP-address: <HOST>.*$"
 
+
+#=================================================
+# SET SSOWAT BASIC AUTH HEADER HANDLING FOR OPDS
+#=================================================
+ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
+
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================


### PR DESCRIPTION
## Problem
Currently, OPDS authentication with user credentials does not work - only with anonymous access enabled (which means anyone that can reach the OPDS endpoint via the network can access it). That is issue #160.

This is caused by SSOWat, specifically its (intended) behavior of, by default, stripping basic auth headers (https://github.com/YunoHost/SSOwat/blob/dev/access.lua#L258-L287) 

OPDS auth worked in the past, but broke last year, probably (I did not research this extensively), with the release of Yunohost 12, where relevant SSOWat behaviours were changed (https://github.com/YunoHost/SSOwat/commit/27f7faaf627e67613e576b3227c71f77160aa115).

This behavior exists because some Ynh apps may want to be aware of different users and their profiles, but delegate the auth functionality entirely to SSOWat, do not integrate with LDAP in any way, and trust the header sent from SSOWat without verifying the password. Then, it would be possible to impersonate a user by setting the username manipulating the basic auth header, if this behavior did not exist. 

However, this scenario is not relevant to Calibre-Web. It does check the password (https://github.com/janeczku/calibre-web/blob/master/cps/usermanagement.py#L52 and https://github.com/janeczku/calibre-web/blob/master/cps/usermanagement.py#L72) in case of OPDS access (https://github.com/janeczku/calibre-web/blob/master/cps/opds.py#L48).

## Solution
As mentioned in packaging documentation https://doc.yunohost.org/en/dev/packaging/advanced/sso_ldap_integration#application-which-provide-an-api, set the `protect_against_basic_auth_spoofing` setting to `false` during install. 

This PR closes #160.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
 - Sort of yes but also no. I did not test this version of the code exactly, but I did apply the equivalent commands from the documentation linked above (`sudo yunohost app setting calibreweb protect_against_basic_auth_spoofing -v false` etc) on my install and tested it. OPDS auth fails with the correct user and wrong pw, and passes with the correct user and correct pw, as expected.  

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
